### PR TITLE
Restrict python>=3.7,<3.11 in conda.yml to be consistent with setup.cfg

### DIFF
--- a/libs/cot/conda.yml
+++ b/libs/cot/conda.yml
@@ -1,6 +1,6 @@
 name: thoughtsource
 dependencies:
-  - python>=3.6
+  - python>=3.7,<3.11
   - pip
   - pip:
     - -e .

--- a/libs/cot/conda.yml
+++ b/libs/cot/conda.yml
@@ -1,6 +1,0 @@
-name: thoughtsource
-dependencies:
-  - python>=3.7,<3.11
-  - pip
-  - pip:
-    - -e .


### PR DESCRIPTION
Without this we get the following error when attempting to create a conda env from conda.yml:
ERROR: Package 'cot' requires a different Python: 3.11.0 not in '<3.11,>=3.7'