### PR TITLE
Map function in generate/evaluate without recaching

### DIFF
--- a/libs/cot/cot/dataloader.py
+++ b/libs/cot/cot/dataloader.py
@@ -246,6 +246,8 @@ class Collection:
 
     def generate(self, name=None, split=None, config={}):
         if ("warn" not in config or config["warn"]) and not config["api_service"]=="mock_api":
+        # more detailed option, but not necessary:
+        # if ("warn" not in config or config["warn"]) and (("api_service" in config and not config["api_service"]=="mock_api") or "api_service" not in config):
             n_samples = self.number_examples(name, split)
             print_warning(config, n_samples)
         if name is None:

--- a/libs/cot/cot/evaluate.py
+++ b/libs/cot/cot/evaluate.py
@@ -317,6 +317,9 @@ def evaluate(dataset, overwrite=False, warn=True, config=None):  # config can be
         evaluate_sample,
         fn_kwargs={"type_": type_, "overwrite": overwrite, "warn": warn},
         features=dataset.info.features,
+        # deleting the cache is necessary in generate if you call it multiple times
+        # not clear if it is needed here, but it doesn't hurt
+        load_from_cache_file = False,
     )
 
     keys = set()

--- a/libs/cot/cot/generate.py
+++ b/libs/cot/cot/generate.py
@@ -26,6 +26,7 @@ def generate_and_extract(data, config):
     """
 
     ds.disable_caching()
+    data.cleanup_cache_files()
 
     if isinstance(data, ds.arrow_dataset.Dataset):
         features = data.info.features

--- a/libs/cot/cot/generate.py
+++ b/libs/cot/cot/generate.py
@@ -53,6 +53,7 @@ def generate_and_extract(data, config):
         with_indices=True,
         fn_kwargs=asdict(config_as_dataclass),
         features=features,
+        load_from_cache_file = False,
     )
 
 
@@ -226,6 +227,9 @@ def full_text_prompts(dataset, prompt_text=True, answer_extraction_text = True):
     _full_text_prompts,
     fn_kwargs={"prompt_text": prompt_text, "answer_extraction_text": answer_extraction_text},
     features=dataset.info.features,
+    # deleting the cache is necessary in generate if you call it multiple times
+    # not clear if it is needed here, but it doesn't hurt
+    load_from_cache_file = False,
     )
 
     return dataset

--- a/libs/cot/tests/unit_tests/test_generating.py
+++ b/libs/cot/tests/unit_tests/test_generating.py
@@ -163,7 +163,6 @@ Therefore, the answer is"""
     )
 
 
-# TODO: this test should not fail:
 def test_generate_change_config() -> None:
     # Dataset loading and selecting a random sample
     collection = Collection(["worldtree"], verbose=False)

--- a/libs/cot/tests/unit_tests/test_generating.py
+++ b/libs/cot/tests/unit_tests/test_generating.py
@@ -164,27 +164,29 @@ Therefore, the answer is"""
 
 
 # TODO: this test should not fail:
-# def test_generate_change_config() -> None:
-#     # 1) Dataset loading and selecting a random sample
-#     collection = Collection(["worldtree"], verbose=False)
-#     collection = collection.select(split="train", number_samples=1)
+def test_generate_change_config() -> None:
+    # Dataset loading and selecting a random sample
+    collection = Collection(["worldtree"], verbose=False)
+    collection = collection.select(split="train", number_samples=1)
 
-#     config = simple_config()
-#     config["instruction_keys"] = ["qa-01"]
+    config = simple_config()
+    config["instruction_keys"] = ["qa-01"]
 
-#     collection.generate(config=config)
+    collection.generate(config=config)
 
-#     # 1) Dataset loading and selecting a random sample
-#     collection = Collection(["worldtree"], verbose=False)
-#     collection = collection.select(split="train", number_samples=1)
+    # Again Dataset loading and selecting a random sample
+    collection = Collection(["worldtree"], verbose=False)
+    collection = collection.select(split="train", number_samples=1)
 
-#     # 2) Language Model generates chains of thought and then extracts answers
-#     config = simple_config()
-#     config["instruction_keys"] = ["qa-02"]
+    config = simple_config()
+    # Set a new the instruction key
+    config["instruction_keys"] = ["qa-02"]
 
-#     collection.generate(config=config)
+    # Generate with a new config
+    collection.generate(config=config)
 
-#     assert collection["worldtree"]["train"][0]["generated_cot"][0]["instruction"] == "qa-02"
+    # Check if the instruction is the one from the new config
+    assert collection["worldtree"]["train"][0]["generated_cot"][0]["instruction"] == "qa-02"
 
 
 

--- a/libs/cot/tests/unit_tests/test_generating.py
+++ b/libs/cot/tests/unit_tests/test_generating.py
@@ -187,7 +187,26 @@ def test_generate_change_config() -> None:
     # Check if the instruction is the one from the new config
     assert collection["worldtree"]["train"][0]["generated_cot"][0]["instruction"] == "qa-02"
 
+def test_generate_twice() -> None:
+    # Dataset loading and selecting a random sample
+    collection = Collection(["worldtree"], verbose=False)
+    collection = collection.select(split="train", number_samples=1)
 
+    config = simple_config()
+    config["instruction_keys"] = ["qa-01"]
+
+    collection.generate(config=config)
+
+    config = simple_config()
+    # Set a new the instruction key
+    config["instruction_keys"] = ["qa-02"]
+
+    # Generate with a new config
+    collection.generate(config=config)
+
+    # Check if both generated_cot are saved and have the correct instructions
+    assert collection["worldtree"]["train"][0]["generated_cot"][0]["instruction"] == "qa-01"
+    assert collection["worldtree"]["train"][0]["generated_cot"][1]["instruction"] == "qa-02"
 
 
 


### PR DESCRIPTION
Deactivate recaching in generate and evaluate.
This makes it possible to call generate multiple times on one collection.
This makes it possible to reload a collection and generate with a new config without recaching the old collection.
The added tests show the improvements, which have been made.