### PR TITLE
give evaluation func the option to return None

### DIFF
--- a/libs/cot/cot/evaluate.py
+++ b/libs/cot/cot/evaluate.py
@@ -295,12 +295,10 @@ def evaluate_sample(example, type_, overwrite, warn):
             if answer["correct_answer"] is not None and not overwrite:
                 continue
             prediction = answer["answer"]
-            if is_correct(
+            answer_eval = is_correct(
                 type_, prediction, dataset_correct_answer, dataset_choices, warn
-            ):
-                answer["correct_answer"] = True
-            else:
-                answer["correct_answer"] = False
+            )
+            answer["correct_answer"] = answer_eval
     return example
 
 


### PR DESCRIPTION
So far evaluation could only output True/False. But in some cases we just want it to leave the answer not evaluated, and therefor it needs to be able to return None.