### PR TITLE
fix feature body in source dataset view

### DIFF
--- a/libs/cot/cot/datasets/svamp/svamp.py
+++ b/libs/cot/cot/datasets/svamp/svamp.py
@@ -115,7 +115,7 @@ class SvampDataset(datasets.GeneratorBasedBuilder):
             features = datasets.Features(
                 {
                     "ID": datasets.Value("string"),
-                    "Body": [datasets.Value("string")],
+                    "Body": datasets.Value("string"),
                     "Question": datasets.Value("string"),
                     "Equation": datasets.Value("string"),
                     "Answer": datasets.Value("float"),


### PR DESCRIPTION
In source view the feature body is shown as list, although it its a string, which makes it an unreadable list of characters. This is now fixed.