### PR TITLE
Fix Streamlit Error

### DIFF
--- a/apps/dataset-viewer/app.py
+++ b/apps/dataset-viewer/app.py
@@ -10,6 +10,8 @@ from datasets import load_dataset
 from cot import Collection
 import yaml
 
+st.set_page_config(page_title="ThoughtSource⚡", layout="wide")
+
 with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config.yml'), 'r') as file:
     config = yaml.safe_load(file)
 
@@ -156,7 +158,7 @@ def display_dataset(dataset):
 
 def run_app():
     
-    st.set_page_config(page_title="ThoughtSource⚡", layout="wide")
+    
 
     # st.title('ThoughtSource⚡ Viewer')
 


### PR DESCRIPTION
streamlit.errors, Streamlit set_page_config() can only be called once per app page, and must be called as the first Streamlit command in your script
![455c97740c29f8ec2117eb647aca3b95](https://github.com/user-attachments/assets/adccaf38-4344-4159-8baa-f6737f17010b)
